### PR TITLE
setup.cfg description updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,5 @@
 universal = 1
 
 [metadata]
-description-file = README.md
+description = The Plivo Python SDK makes it simpler to integrate communications into your Python applications using the Plivo REST API. Using the SDK, you will be able to make voice calls, send SMS and generate Plivo XML to control your call flows.
+long_description = file: README.md


### PR DESCRIPTION
Use "long_description" over "description-file", add "description" field with shorter description.

Addresses deprecation issues with setuptools invalid dash-separated options:
    https://github.com/pypa/setuptools/blob/7c859e017368360ba66c8cc591279d8964c031bc/setuptools/dist.py#L645-L655

See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata for more information on valid options.
